### PR TITLE
allow non-GFM markdown; fixes #37

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -26,7 +26,8 @@ class MarkdownScrlSync
       isMarkdown = (editor)->
         for name in ["GitHub Markdown", "CoffeeScript (Literate)"]
           return true if editor.getGrammar().name is name
-        return false
+        [fpath, ..., fext] = editor.getPath().split('.')
+        return fext == 'md'
       if editor instanceof TextEditor and
          editor.alive                 and
          isMarkdown(editor)


### PR DESCRIPTION
Will now detect `isMarkdown` to be true if the file extension is `.md` - irrespective of the grammar.